### PR TITLE
Revert "Install it in /usr/bin?"

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,18 +1,32 @@
-# Maintainer: Adrian Lopez <zeioth@hotmail.com>
+# This is an example PKGBUILD file. Use this as a start to creating your own,
+# and remove these comments. For more information, see 'man PKGBUILD'.
+# NOTE: Please fill out the license field for your package! If it is unknown,
+# then please put 'unknown'.
 
+# Maintainer: Adrian Lopez <zeioth@hotmail.com>
 pkgname=wofi-calc
 pkgver=1.0
-pkgrel=2
+pkgrel=1
+epoch=
 pkgdesc="A simple calculator for wofi, inspired in rofi-calc."
-arch=('any')
-url='https://github.com/Zeioth/wofi-calc'
+arch=(x86_64 i686)
+url="https://github.com/Zeioth/wofi-calc.git"
 license=('MIT')
+groups=()
 depends=(wofi libqalculate)
 makedepends=(wofi libqalculate)
+checkdepends=()
+optdepends=()
 provides=(wofi-calc)
-conflicts=(wofi-calc-git)
-source=(https://raw.githubusercontent.com/Zeioth/wofi-calc/main/wofi-calc.sh)
-sha512sums=('34592bacfa7b58f8f327095fada0fa7d4d1b79f975994e4c6e9679ebe97c8355ad02edee357835c05977fb2c6ebb87f3db4cbc363446a67d8dbf316740a080b0')
+conflicts=(wofi-calc)
+replaces=()
+backup=()
+options=()
+install=
+changelog=
+source=("git+$url")
+noextract=()
+md5sums=('SKIP')
 validpgpkeys=()
 
 pkgver() {
@@ -21,6 +35,6 @@ pkgver() {
 }
 
 package() {
-  mkdir -p "$pkgdir"/usr/bin
-  install -m755 "${srcdir}"/wofi-calc/wofi-calc.sh "$pkgdir"/usr/bin/wofi-calc
+    cp "${srcdir}"/wofi-calc/wofi-calc.sh ~/.local/bin/wofi-calc
+    chmod u+x ~/.local/bin/wofi-calc
 }


### PR DESCRIPTION
Reverts Zeioth/wofi-calc#2

The installer does not install the file in /usr/bin as I think you was intending. please don't submit pull requests without testing the PKGBUILD, as rn I don't have a lot of time to test myself.